### PR TITLE
Resolve Wireless Permission Issue on CN Devices

### DIFF
--- a/RealityMixer/Calibration/ViewControllers/CalibrationConnectionViewController.swift
+++ b/RealityMixer/Calibration/ViewControllers/CalibrationConnectionViewController.swift
@@ -89,6 +89,14 @@ final class CalibrationConnectionViewController: UIViewController {
             guard let self = self else { return }
 
             // FIXME: Do this in a way that doesn't block the main thread
+                                                              
+                                                              
+            // Making Dummy Request to Apple Server to solve Chinese Device wireless permission issue
+            if let url = URL(string: "https://captive.apple.com") {
+                do {
+                    let contents = try String(contentsOf: url)
+                    print(contents)
+                }catch {}}
 
             let client = TCPClient(address: address, port: port)
 


### PR DESCRIPTION
Per Chinese regulation, apps that runs on devices sold in China Mainland are supposed to prompt for Wireless/Cellular Data Permission before using Local Network or Internet.
iOS is supposed to trigger a prompt for the permission prompt when the devices tries to use networking, but since this app uses SwiftSocket, it doesn't trigger the permission prompt.
The code added makes dummy request to captive.apple.com which triggers the permission prompt to pop up.